### PR TITLE
Use the DAP (disk access packet) to support loading larger executables

### DIFF
--- a/bootelf.asm
+++ b/bootelf.asm
@@ -35,7 +35,7 @@ stopread:
   %include "memmap.asm"
 
   ; Comment out to skip getting a framebuffer
-  ; %include "framebuffer.asm"
+  %include "framebuffer.asm"
 
   ; We have now abused the BIOS as much as we need/want to.
   ; Time to go to 64 bits.


### PR DESCRIPTION
This change uses the Disk Access Packet. It means floppies will not work, however, this allows for executables larger than 63 sectors to be loaded.