### PR TITLE
save three bytes

### DIFF
--- a/bootelf.asm
+++ b/bootelf.asm
@@ -8,7 +8,7 @@ org 0x7C00
 _start:
   xor bx, bx
   mov ds, bx
-  mov ss, bx
+  mov es, bx
   mov cx, elf_num_blocks
 
   ; Read ELF file from disk

--- a/framebuffer.asm
+++ b/framebuffer.asm
@@ -99,8 +99,8 @@ get_video_loop:
   jne get_video_loop
 
   ; We got it!
-  mov bx, [di + vesa_pitch_offset]
-  mov [bootelf_fb_pitch], bx
+  mov ax, [di + vesa_pitch_offset]
+  mov [bootelf_fb_pitch], ax
 
   mov eax, [di + vesa_framebuffer_offset]
   mov [bootelf_fb_addr], eax

--- a/paging.asm
+++ b/paging.asm
@@ -23,7 +23,7 @@ morel1map:
   xor ax, ax
 moremappings:
   mov byte [di], mapping_2m ; Third level
-  mov word [di + 2], ax
-  add di, 8
+  stosw
+  add di, 6
   add ax, 32
   jnc moremappings


### PR DESCRIPTION
* initialize `es` instead of `ss`, because initializing `ss` without setting `sp` as well immediately after is a bug anyway, and BIOS is guaranteed to provide a small stack, as discussed in private communication with N00byEdge
* exploit more efficient `mov [offset], ax` encoding in `framebuffer.asm`
* exploit `stosw` (with the now-initialized `es`) in `paging.asm`